### PR TITLE
Add the correct includes now that we don't "configure" via CMake.

### DIFF
--- a/gzlib.c
+++ b/gzlib.c
@@ -6,8 +6,10 @@
 #include "gzguts.h"
 
 #if defined(_WIN32) && !defined(__BORLANDC__)
+#include <io.h>
 #  define LSEEK _lseeki64
 #else
+#include <unistd.h>
 #if defined(_LARGEFILE64_SOURCE) && _LFS64_LARGEFILE-0
 #  define LSEEK lseek64
 #else

--- a/gzread.c
+++ b/gzread.c
@@ -5,6 +5,10 @@
 
 #include "gzguts.h"
 
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
 /* Local functions */
 local int gz_load OF((gz_statep, unsigned char *, unsigned, unsigned *));
 local int gz_avail OF((gz_statep));

--- a/gzwrite.c
+++ b/gzwrite.c
@@ -5,6 +5,10 @@
 
 #include "gzguts.h"
 
+#if !defined(_WIN32)
+#include <unistd.h>
+#endif
+
 /* Local functions */
 local int gz_init OF((gz_statep));
 local int gz_comp OF((gz_statep, int));


### PR DESCRIPTION
Resolves a few implicit declaration warnings.
